### PR TITLE
Team deletion fix

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -111,8 +111,8 @@ class TeamsController < ApplicationController
     def show
         @team = Team.find(params[:id])
         @members = @team.members
-        @member_count = @members.count
         @assignment = Assignment.find_by_team_id(@team.id)
+        @member_count = @members.count
 
 
         @project = @assignment.nil? ? nil : Project.find(@assignment.project_id)

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -111,6 +111,7 @@ class TeamsController < ApplicationController
     def show
         @team = Team.find(params[:id])
         @members = @team.members
+        @member_count = @members.count
         @assignment = Assignment.find_by_team_id(@team.id)
 
 

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -3,7 +3,7 @@
 
 <% if @team.is_leader?(current_user) || current_user.admin? %>
   <h2><%= link_to "Edit", edit_team_path(@team) %>
-  <% if !@assignment && @member_count <=1 %>
+  <% if @member_count <=1 and !@assignment %>
     | <%= link_to "Delete", @team, method: :delete,
                   data: {confirm: "You sure?"} %>
   <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -3,8 +3,10 @@
 
 <% if @team.is_leader?(current_user) || current_user.admin? %>
   <h2><%= link_to "Edit", edit_team_path(@team) %>
+  <% if !@assignment && @member_count <=1 %>
     | <%= link_to "Delete", @team, method: :delete,
                   data: {confirm: "You sure?"} %>
+  <% end %>
   </h2>
 <% end %>
 <% if current_user.is_member?(@team) %><%# && !@team.is_leader?(current_user) %>


### PR DESCRIPTION
Team leader can now delete a team only if the following 2 conditions are met:
1. No project has been assigned to the team.
2. The team has no other members.